### PR TITLE
Be a better Kyriba API consumer

### DIFF
--- a/airbyte-integrations/connectors/source-kyriba/source_kyriba/source.py
+++ b/airbyte-integrations/connectors/source-kyriba/source_kyriba/source.py
@@ -40,12 +40,13 @@ class KyribaStream(HttpStream):
         self,
         gateway_url: str,
         client: KyribaClient,
-        start_date: str,
+        start_date: str = None,
         end_date: str = None,
         excluded_banks: list = [],
     ):
+        DEFAULT_START_DATE = (date.today() - timedelta(days=7))
         self.gateway_url = gateway_url
-        self.start_date = date.fromisoformat(start_date) or date.today()
+        self.start_date = DEFAULT_START_DATE if start_date is None else date.fromisoformat(start_date)
         self.end_date = date.fromisoformat(end_date) if end_date else None
         self.excluded_banks = excluded_banks
         self.client = client

--- a/airbyte-integrations/connectors/source-kyriba/source_kyriba/spec.json
+++ b/airbyte-integrations/connectors/source-kyriba/source_kyriba/spec.json
@@ -4,7 +4,7 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Kyriba Spec",
     "type": "object",
-    "required": ["domain", "username", "password", "start_date"],
+    "required": ["domain", "username", "password"],
     "additionalProperties": false,
     "properties": {
       "domain": {
@@ -27,7 +27,7 @@
       },
       "start_date": {
         "type": "string",
-        "description": "The date the sync should start from.",
+        "description": "The date the sync should start from. If not set, the sync will start from 7 days ago.",
         "title": "Start Date",
         "examples": ["2021-01-10"],
         "pattern": "^\\d{4}\\-(0[1-9]|1[012])\\-(0[1-9]|[12][0-9]|3[01])$"

--- a/airbyte-integrations/connectors/source-kyriba/unit_tests/test_bank_balances_stream.py
+++ b/airbyte-integrations/connectors/source-kyriba/unit_tests/test_bank_balances_stream.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2022 Airbyte, Inc., all rights reserved.
 #
 
-from datetime import date
+from datetime import date, timedelta
 from unittest.mock import MagicMock
 
 import pytest
@@ -75,3 +75,10 @@ def test_request_params(patch_base_class):
         "dateType": "VALUE",
     }
     assert params == expected
+
+
+def test_no_start_date(patch_base_class):
+    conf = config()
+    conf["start_date"] = None
+    stream = CashBalancesStream(**conf)
+    assert stream.start_date == date.today() - timedelta(days=7)

--- a/airbyte-integrations/connectors/source-kyriba/unit_tests/test_cash_balances_stream.py
+++ b/airbyte-integrations/connectors/source-kyriba/unit_tests/test_cash_balances_stream.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2022 Airbyte, Inc., all rights reserved.
 #
 
-from datetime import date
+from datetime import date, timedelta
 from unittest.mock import MagicMock
 
 import pytest
@@ -75,3 +75,10 @@ def test_request_params(patch_base_class):
         "dateType": "VALUE",
     }
     assert params == expected
+
+
+def test_no_start_date(patch_base_class):
+    conf = config()
+    conf["start_date"] = None
+    stream = CashBalancesStream(**conf)
+    assert stream.start_date == date.today() - timedelta(days=7)

--- a/airbyte-integrations/connectors/source-kyriba/unit_tests/test_cash_flows.py
+++ b/airbyte-integrations/connectors/source-kyriba/unit_tests/test_cash_flows.py
@@ -3,7 +3,7 @@
 #
 
 
-from datetime import date
+from datetime import date, timedelta
 from unittest.mock import MagicMock
 
 import requests
@@ -98,3 +98,10 @@ def test_parse_response(patch_base_class):
     resp_data = {"results": [{"date": {"updateDateTime": "2022-03-01T00:00:00Z"}}]}
     resp.json = MagicMock(return_value=resp_data)
     assert next(stream.parse_response(resp)) == {"updateDateTime": "2022-03-01T00:00:00Z"}
+
+
+def test_no_start_date(patch_base_class):
+    conf = config()
+    conf["start_date"] = None
+    stream = CashFlows(**conf)
+    assert stream.start_date == date.today() - timedelta(days=7)

--- a/airbyte-integrations/connectors/source-kyriba/unit_tests/test_incremental_streams.py
+++ b/airbyte-integrations/connectors/source-kyriba/unit_tests/test_incremental_streams.py
@@ -4,6 +4,7 @@
 
 
 from airbyte_cdk.models import SyncMode
+from datetime import date, timedelta
 from pytest import fixture
 from source_kyriba.source import IncrementalKyribaStream
 
@@ -70,3 +71,10 @@ def test_min_request_params(patch_incremental_base_class):
     inputs = {"stream_state": {}, "stream_slice": {}, "next_page_token": {}}
     expected = {"sort": "updateDateTime", "filter": "updateDateTime=gt='2022-01-01T00:00:00Z'"}
     assert stream.request_params(**inputs) == expected
+
+
+def test_no_start_date(patch_incremental_base_class):
+    conf = config()
+    conf["start_date"] = None
+    stream = IncrementalKyribaStream(**conf)
+    assert stream.start_date == date.today() - timedelta(days=7)

--- a/airbyte-integrations/connectors/source-kyriba/unit_tests/test_streams.py
+++ b/airbyte-integrations/connectors/source-kyriba/unit_tests/test_streams.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2022 Airbyte, Inc., all rights reserved.
 #
 
+from datetime import date, timedelta
 from http import HTTPStatus
 from unittest.mock import MagicMock
 
@@ -119,3 +120,10 @@ def test_unnest(patch_base_class):
     data = {"uuid": "uuid", "nested": {"date": "date"}}
     expected = {"uuid": "uuid", "date": "date"}
     assert stream.unnest("nested", data) == expected
+
+
+def test_no_start_date(patch_base_class):
+    conf = config()
+    conf["start_date"] = None
+    stream = KyribaStream(**conf)
+    assert stream.start_date == date.today() - timedelta(days=7)


### PR DESCRIPTION
Kyriba source connector: Make start_date an optional field. Now defaults to 7 days ago. This will help us be a better Kyriba API consumer.