### PR TITLE
force parquet to update to 1.15.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -210,7 +210,23 @@ allprojects {
 
 // Java projects common configurations
 subprojects { subproj ->
-
+    configurations.all {
+        resolutionStrategy {
+            force 'org.apache.parquet:parquet-common:1.15.1'
+            force 'org.apache.parquet:parquet-encoding:1.15.1'
+            force 'org.apache.parquet:parquet-column:1.15.1'
+            force 'org.apache.parquet:parquet-hadoop:1.15.1'
+            force 'org.apache.parquet:parquet-avro:1.15.1'
+            force 'org.apache.parquet:parquet-format-structures:1.15.1'
+            
+            // Ensure all transitive dependencies also use 1.15+
+            eachDependency { DependencyResolveDetails details ->
+                if (details.requested.group == 'org.apache.parquet') {
+                    details.useVersion '1.15.1'
+                }
+            }
+        }
+    }
 
     configurations {
         runtimeClasspath


### PR DESCRIPTION
## What
Updating the org.apache.parquet packages to 1.15.1 to cover a [critical vulnerability](https://www.endorlabs.com/learn/critical-rce-vulnerability-in-apache-parquet-cve-2025-30065---advisory-and-analysis).

## How
Upgrade org.apache.parquet in the root build.gradle file.

## 🚨 User Impact 🚨
Should have no visible impact to users. An under the hood change.

## Testing

Recreated one of the syncs on the staging environment with these changes. Ran and succeeded.

